### PR TITLE
fix(svelte-katex): properly export types

### DIFF
--- a/packages/svelte-katex/package.json
+++ b/packages/svelte-katex/package.json
@@ -10,12 +10,18 @@
   },
   "exports": {
     "./package.json": "./package.json",
-    "./Katex.svelte": "./Katex.svelte",
-    ".": "./Katex.svelte"
+    ".": {
+      "svelte": "./index.js",
+      "types": "./index.d.ts"
+    },
+    "./Katex.svelte": {
+      "svelte": "./Katex.svelte",
+      "types": "./Katex.svelte.d.ts"
+    }
   },
   "main": "./index.js",
   "module": "./index.js",
-  "types": "./Katex.d.ts",
+  "types": "./index.d.ts",
   "type": "module",
   "svelte": "./Katex.svelte",
   "repository": {


### PR DESCRIPTION
fixes types for `svelte-katex` on modern apps